### PR TITLE
docs: remove duplicated flag in run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ python3 rae2anki.py -i 23-8.txt -e exceptions.txt -o flashcards.csv -x
 
 If you have already extracted the definitions:
 ```sh
-python3 rae2anki.py -d words.json -e exceptions.txt -o flashcards.csv -d words.json
+python3 rae2anki.py -d words.json -e exceptions.txt -o flashcards.csv
 ```


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to correct a duplicate flag in the example command for `rae2anki.py`. The change ensures the command is accurate and avoids redundancy.