### PR TITLE
Update dependencies for Python 3.13 compatibility and Scrapy 2.15

### DIFF
--- a/rae2json/rae2json/pipelines.py
+++ b/rae2json/rae2json/pipelines.py
@@ -9,15 +9,23 @@ import json
 from itemadapter import ItemAdapter
 
 class Rae2JsonPipeline:
-    def open_spider(self, spider):
-        output_file = spider.settings.get('OUTPUT_FILE', 'output.json')
-        self.file = open(output_file, 'w', encoding='utf-8')
+    def __init__(self, output_file):
+        self.output_file = output_file
+        self.file = None
         self.data = {}
 
-    def close_spider(self, spider):
+    @classmethod
+    def from_crawler(cls, crawler):
+        output_file = crawler.settings.get('OUTPUT_FILE', 'output.json')
+        return cls(output_file)
+    
+    def open_spider(self):
+        self.file = open(self.output_file, 'w', encoding='utf-8')
+
+    def close_spider(self):
         json.dump(self.data, self.file, ensure_ascii=False)
         self.file.close()
 
-    def process_item(self, item, spider):
+    def process_item(self, item):
         self.data.update(item)
         return item

--- a/rae2json/rae2json/spiders/raespiderdefinitions.py
+++ b/rae2json/rae2json/spiders/raespiderdefinitions.py
@@ -27,7 +27,7 @@ class RaespiderdefinitionsSpider(scrapy.Spider):
         
         self.start_urls = ["https://dle.rae.es/{}".format(word) for word in all_words]
    
-    def start_requests(self):
+    async def start(self):
         for url in self.start_urls:
             yield scrapy.Request(url, headers={'User-Agent': random.choice(self.USER_AGENT_LIST)})
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Scrapy==2.9.0
-Twisted==22.10.0
+Scrapy==2.15.2


### PR DESCRIPTION
- Bump `scrapy` to 2.15.2 (version 2.9 was not compatible with Python >=3.12)
- Adapt the code to remove deprecation warnings

Addreses #10 